### PR TITLE
Versioning_issue

### DIFF
--- a/jockey/stirrups/video_search.py
+++ b/jockey/stirrups/video_search.py
@@ -30,7 +30,7 @@ class MarengoSearchInput(BaseModel):
     """Help to ensure the video-search worker provides valid arguments to any tool it calls."""
     query: str | dict = Field(description="Search query to run on a collection of videos.")
     index_id: str = Field(description="Index ID which contains a collection of videos.")
-    top_n: int = Field(description="Get the top N clips or videos as search results.", gt=0, le=10, default=3)
+    top_n: int = Field(description="Get the top N clips or videos as search results.", default=3)
     group_by: GroupByEnum = Field(description="Search for clips or videos.", default=GroupByEnum.CLIP)
     search_options: List[SearchOptionsEnum] = Field(description="Which modalities to consider when running a query on a collections of videos.", 
                                                 default=[SearchOptionsEnum.VISUAL, SearchOptionsEnum.CONVERSATION])


### PR DESCRIPTION
As we discussed with Travis, the LangGraph container is using a different version of LangChain, and the Pydantic version they are using has changed in the latest update of LangGraph (Cloud)

Which resulting in issue:
ph-api-1       |   File "/usr/local/lib/python3.11/site-packages/pydantic/v1/schema.py", line 1021, in get_annotation_from_field_info
langgraph-api-1       |     raise ValueError(
langgraph-api-1       | ValueError: On field "top_n" the following field constraints are set but not enforced: gt, le.
langgraph-api-1       | For more details see
