### PR TITLE
Restructure the Usage section for clarity and separate developer content

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,12 @@ For OpenAI:
 
 ## Usage
 
-This section provides instructions on how to deploy and use Jockey. Follow the steps in one of the following sections, depending on how you wish to deploy and use Jockey - in the terminal or with the LangGraph API server.
+This section provides instructions on how to deploy and use Jockey. Note that Jockey supports the following deployment options:
+
+- Terminal-based deployment: Ideal for quick testing, development work, and debugging.
+- LangGraph API server deployment: Suitable for building and debugging end-to-end user applications.
+
+This document covers the terminal-based deployment. If you're a developer looking to integrate Jockey into your application, see the [Deploy and Use Jockey with the LangGraph API Server](docs/langgraph-api-server.md)
 
 ### Deploy and use Jockey in the terminal
 
@@ -192,33 +197,6 @@ To adjust the verbosity of the output, modify the [`parse_langchain_events_termi
 
 Note that the tags for the individual components are set in [app.py](jockey/app.py).
 
-### Deploy and Use Jockey with the LangGraph API Server
-
-The LangGraph API Server deployment is suitable for building end-to-end user applications.
-
-1. Activate your virtual environment:
-    ```sh
-    source venv/bin/activate
-    ```
-2. Run the command below and wait for the message indicating that the server is running. By default, it will be available at [http://localhost:8124](http://localhost:8124):
-    ```sh
-    python3 -m jockey server
-    ```
-3. Once the server is running, you can interact with Jockey using HTTP requests or the [LangGraph Python SDK](https://pypi.org/project/langgraph-sdk/).
-
-#### Debug using the LangGraph Debugger
-
-The LangGraph API Server includes a debugger that you can use for monitoring and debugging Jockey:
-
-1. Open a web browser and navigate to [http://localhost:8124](http://localhost:8124).
-    ![LangGraph Debugger](assets/langgraph_debugger.png)
-2. Select "jockey" under the "Assistants" section.
-3. Click "New Thread" to start a new conversation with Jockey.
-4. Use the debugger to step into the Jockey instance. You can add breakpoints to examine and validate the graph state for any given input.
-    ![Jockey LangGraph Debugger](assets/jockey_langgraph_debugger.png)
-
-[LangGraph Debugger UI Walkthrough](https://www.loom.com/share/9b7594df37294edcaed31a4b2d901d7b?sid=28a9019d-0ac4-4ca6-a874-d334e2ab1221).
-
 ## Integrate Jockey Into Your Application
 
 To integrate Jockey into your application, use an HTTP client library or the [LangGraph Python SDK](https://pypi.org/project/langgraph-sdk/).
@@ -226,9 +204,10 @@ To integrate Jockey into your application, use an HTTP client library or the [La
 For a basic example of how to interact with Jockey programmatically, refer to the [client.ipynb](client.ipynb) Jupyter notebook in the project repository. For more detailed information, see the [LangGraph Examples](https://github.com/langchain-ai/langgraph-example) page. 
 
 
-## Additional documentation
+## Additional Documentation
 
 - [Troubleshooting](docs/troubleshooting.md)
 - [Support](docs/support.md)
 - [Architecture](docs/architecture.md)
 - [Customize Jockey](docs/customize-jockey.md)
+- [Deploy and Use Jockey with the LangGraph API Server](docs/langgraph-api-server.md)

--- a/docs/langgraph-api-server.md
+++ b/docs/langgraph-api-server.md
@@ -1,0 +1,26 @@
+# Deploy and Use Jockey with the LangGraph API Server
+
+The LangGraph API Server deployment is suitable for building and debugging end-to-end user applications.
+
+1. Activate your virtual environment:
+    ```sh
+    source venv/bin/activate
+    ```
+2. Run the command below and wait for the message indicating that the server is running. By default, it will be available at [http://localhost:8124](http://localhost:8124):
+    ```sh
+    python3 -m jockey server
+    ```
+3. Once the server is running, you can interact with Jockey using HTTP requests or the [LangGraph Python SDK](https://pypi.org/project/langgraph-sdk/).
+
+#### Debug using the LangGraph Debugger
+
+The LangGraph API Server includes a debugger that you can use for monitoring and debugging Jockey:
+
+1. Open a web browser and navigate to [http://localhost:8124](http://localhost:8124).
+    ![LangGraph Debugger](assets/langgraph_debugger.png)
+2. Select "jockey" under the "Assistants" section.
+3. Click "New Thread" to start a new conversation with Jockey.
+4. Use the debugger to step into the Jockey instance. You can add breakpoints to examine and validate the graph state for any given input.
+    ![Jockey LangGraph Debugger](assets/jockey_langgraph_debugger.png)
+
+[LangGraph Debugger UI Walkthrough](https://www.loom.com/share/9b7594df37294edcaed31a4b2d901d7b?sid=28a9019d-0ac4-4ca6-a874-d334e2ab1221).


### PR DESCRIPTION
This PR restructures the Usage section to improve clarity for the general audience while ensuring developers can find the necessary information.