### PR TITLE
servers_hide

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -99,8 +99,8 @@ app.post("/stream_events", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
 
   // Use Axios to interact with the remote service
-  const externalServiceUrl = "https://twelve-jockey-b8564d2f3502.herokuapp.com/jockey/astream_events";
-
+  const externalServiceUrl = "";
+  // Add externalURL if using stream events without SDK 
   // Send request to external service with appropriate data
   const response = axios.post(externalServiceUrl, {
       input: inputData,

--- a/frontend/src/apis/apiConfig.js
+++ b/frontend/src/apis/apiConfig.js
@@ -1,12 +1,12 @@
 import axios from "axios";
 
-const SERVER_BASE_URL = new URL(`https://twelve-server3-8f54ec333541.herokuapp.com/`)
+const SERVER_BASE_URL = new URL(process.env.BASE_SERVER)
 
 const apiConfig = {
   TWELVE_LABS_API: axios.create({
     baseURL: SERVER_BASE_URL.toString(),
   }),
-  PROXY_SERVER: "https://twelve-fast-6e09a0ec0080.herokuapp.com/stream_events",
+  PROXY_SERVER: process.env.PROXY_SERVER,
   INDEXES_URL: "/indexes",
   SEARCH_URL: "/search",
   TASKS_URL: "/tasks",

--- a/frontend/src/apis/apiConfig.js
+++ b/frontend/src/apis/apiConfig.js
@@ -6,7 +6,7 @@ const apiConfig = {
   TWELVE_LABS_API: axios.create({
     baseURL: SERVER_BASE_URL.toString(),
   }),
-  PROXY_SERVER: process.env.PROXY_SERVER,
+  PROXY_SERVER: "http://0.0.0.0:8000/stream_events",
   INDEXES_URL: "/indexes",
   SEARCH_URL: "/search",
   TASKS_URL: "/tasks",

--- a/frontend/src/server/serverConfig.ts
+++ b/frontend/src/server/serverConfig.ts
@@ -1,7 +1,0 @@
-export const ServerConfig = {
-    ServerForGeneralChat: 'https://15e6-2600-8802-3911-f100-e934-c048-c6a9-2619.ngrok-free.app/worker_generate_stream3',
-    ServerForASRRequests: 'https://15e6-2600-8802-3911-f100-e934-c048-c6a9-2619.ngrok-free.app/asr',
-    ServerForASR: 'http://172.16.6.55:40093/worker_generate_stream',
-    ServerForTwelveML: 'http://172.16.6.55:40083/worker_generate_stream'
-};
-


### PR DESCRIPTION
What I'm basically trying to do is remove any mention of the servers here. We did this before to ensure all the hackathon contributors could have an easy setup and start working using our servers. Later on, the servers will be stored in environment variables and provided upon request.