### PR TITLE
Permission denied while `langgraph up` on Ubuntu

### DIFF
--- a/jockey/cli.py
+++ b/jockey/cli.py
@@ -1,6 +1,8 @@
 import uuid
 import os
 import subprocess
+import shutil
+import platform
 from rich.console import Console
 from jockey.util import parse_langchain_events_terminal
 from langchain_core.messages import HumanMessage
@@ -35,18 +37,45 @@ async def run_jockey_terminal():
 def run_jockey_server():
     """Quickstart function to create run Jockey in a LangGraph API container for easy dev work.
     We use the default version of Jockey for this."""
+    os_name = platform.system()
+
     jockey_package_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
     langgraph_json_file_path = os.path.join(jockey_package_dir, "langgraph.json")
     compose_file_path = os.path.join(jockey_package_dir, "compose.yaml")
+    langgraph_data_dir = os.path.join(jockey_package_dir, ".langgraph-data")
 
-    langgraph_cli_command = [
-        "langgraph", 
-        "up", 
-        "-c", langgraph_json_file_path, 
-        "-d", compose_file_path, 
-        "--recreate", 
-        "--verbose"
-    ]
+    # Find the langgraph executable dynamically
+    langgraph_path = shutil.which("langgraph")
+    if not langgraph_path:
+        print("Error: langgraph is not installed or not found in PATH.")
+        return
+
+    # Check if the directory is writable
+    if not os.access(langgraph_data_dir, os.W_OK):
+        print(f"Warning: You do not have write access to the {langgraph_data_dir} directory.")
+        if os_name == "Linux":
+            print("Attempting to use sudo on Linux (Ubuntu).")
+            langgraph_cli_command = [
+                "sudo", langgraph_path,  # Use sudo for elevated permissions on Linux
+                "up",
+                "-c", langgraph_json_file_path,
+                "-d", compose_file_path,
+                "--recreate",
+                "--verbose"
+            ]
+        else:
+            print("Please check permissions or run the command with elevated privileges.")
+            return
+    else:
+        # No sudo required if write access is present
+        langgraph_cli_command = [
+            langgraph_path,
+            "up",
+            "-c", langgraph_json_file_path,
+            "-d", compose_file_path,
+            "--recreate",
+            "--verbose"
+        ]
 
     print(f"Using langgraph-cli command:\n\t {str.join(' ', langgraph_cli_command)}")
 


### PR DESCRIPTION
I know your system prerequisite should be Mac OS, but I found we can use `jockey server` on Ubuntu after solving only the permission problem.

I added conditional logic in the script to determine whether to prepend sudo to the command when running on Ubuntu, but skip it on macOS if it’s not necessary.

### Parent Issue
#68 

### Permission Error on Ubuntu
I am working on this project on Ubuntu:22.04 and got this reading permission error in run_jockey_server() of [jockey/cli.py](https://github.com/twelvelabs-io/tl-jockey/issues/jockey/cli.py).
```
#5 ERROR: error from sender: open /home/young/project/twelvelabs/tl-jockey/.langgraph-data: permission denied
------
 > [langgraph-api internal] load build context:
------
failed to solve: error from sender: open /home/young/project/twelvelabs/tl-jockey/.langgraph-data: permission denied
I am using the below command as a temporary workaround. I am gonna work on recognizing the OS to determine what cli should be used.

langgraph_cli_command = [
        "sudo",
     "/home/young/miniconda3/envs/jockey/bin/langgraph",
        # "langgraph", 
        "up", 
        "-c", langgraph_json_file_path, 
        "-d", compose_file_path, 
        "--recreate", 
        "--verbose"
    ]
```