### PR TITLE
add_specific_1sec_buffer

### DIFF
--- a/jockey/util.py
+++ b/jockey/util.py
@@ -119,7 +119,19 @@ def download_video(video_id: str, index_id: str, start: float, end: float) -> st
     if os.path.isfile(video_path) is False:
         try:
             duration = end - start
-            ffmpeg.input(filename=hls_uri, strict="experimental", loglevel="quiet", ss=start, t=duration).output(video_path, vcodec="copy", acodec="copy").run()
+            buffer = 1  # Add a 1-second buffer on each side
+            ffmpeg.input(filename=hls_uri, strict="experimental", loglevel="quiet", ss=max(0, start-buffer), t=duration+2*buffer) \
+                .output(video_path, vcodec="libx264", acodec="aac", avoid_negative_ts="make_zero", fflags="+genpts") \
+                .run()
+
+            # Then trim the video more precisely
+            output_trimmed = f"{os.path.splitext(video_path)[0]}_trimmed.mp4"
+            ffmpeg.input(video_path, ss=buffer, t=duration) \
+                .output(output_trimmed, vcodec="copy", acodec="copy") \
+                .run()
+
+            # Replace the original file with the trimmed version
+            os.replace(output_trimmed, video_path)
         except Exception as error:
             error_response = {
                 "message": f"There was an error downloading the video with Video ID: {video_id} in Index ID: {index_id}. "


### PR DESCRIPTION
 adds 1-second buffer on each side of the requested clip, which helps to ensure that the desired content is fully captured, even if there are slight inaccuracies in seeking. 
 
 Tested different scenarios, used prompts like this one: 
 
 Using index [OurTwelveLabsIndexHere] please follow these steps: 1. Find a touchdown video in the index and select a 5-second segment that includes the moment the player crosses the goal line. 2. From this 5-second segment, create three shorter clips: a. A 0.5-second clip starting exactly when the player's foot touches the goal line. b. A 1-second clip starting 2 seconds into the 5-second segment. c. A 0.75-second clip from the very end of the 5-second segment. 3. Combine these three clips into a single video in this order: b, a, c (the 1-second clip, then the 0.5-second clip, then the 0.75-second clip). 4. Name the output file 'precise_short_clips_test.mp4'.