### PR TITLE
hotfix_always_videos

### DIFF
--- a/jockey/stirrups/video_editing.py
+++ b/jockey/stirrups/video_editing.py
@@ -63,7 +63,13 @@ def combine_clips(clips: List[Dict], output_filename: str, index_id: str) -> str
             input_streams.append(clip_audio_input_stream)
 
         output_filepath = os.path.join(os.environ["HOST_PUBLIC_DIR"], index_id, output_filename)
-        ffmpeg.concat(*input_streams, v=1, a=1).output(output_filepath, acodec="libmp3lame").overwrite_output().run()
+        ffmpeg.concat(*input_streams, v=1, a=1).output(
+            output_filepath, 
+            vcodec="libx264",   
+            acodec="libmp3lame", 
+            video_bitrate="1M",
+            audio_bitrate="192k"
+        ).overwrite_output().run()
 
         return output_filepath
     except Exception as error:

--- a/jockey/stirrups/video_editing.py
+++ b/jockey/stirrups/video_editing.py
@@ -59,8 +59,7 @@ def combine_clips(clips: List[Dict], output_filename: str, index_id: str) -> str
             clip_video_input_stream = clip_video_input_stream.filter("setpts", "PTS-STARTPTS")
             clip_audio_input_stream = clip_audio_input_stream.filter("asetpts", "PTS-STARTPTS")
             
-            input_streams.append(clip_video_input_stream)
-            input_streams.append(clip_audio_input_stream)
+            input_streams.extend([clip_video_input_stream, clip_audio_input_stream])
 
         output_filepath = os.path.join(os.environ["HOST_PUBLIC_DIR"], index_id, output_filename)
         ffmpeg.concat(*input_streams, v=1, a=1).output(


### PR DESCRIPTION
Re-encode both video and audio in combine_clips() function

This PR modifies the combine_clips() function to always re-encode both video and audio when combining clips.

Key changes:
- Use libx264 for video encoding
- Continue using libmp3lame for audio encoding
- Set specific video and audio bitrates for consistent quality

Note => it increase the time it takes to combine clips, especially for longer videos or when dealing with many clips. (Because of this additional video re-encoding step). 

Testing: I used all of the prompts related to using combine clips tool, like this one =>  
"Find top 2 clips of touchownd for index [indexID] and combine them using combine-clips tool"

That is just a hot fix for now, I'm planing to  work on more complex implementation because of it will be way more efficient long term:  Use ffprobe to validate the original video codecs of all the input streams and then dynamically decide wether to re-encode or not
