### PR TITLE
final_worker_video_urls_setup

### DIFF
--- a/frontend/src/apis/streamEventsApis.js
+++ b/frontend/src/apis/streamEventsApis.js
@@ -3,9 +3,7 @@ import { Client } from "@langchain/langgraph-sdk";
 
 export const streamEvents = async (ActionType, dispatch, inputBox, setStreamData, arrayMessages) => {
   dispatch({ type: ActionType.SET_LOADING, payload: true })
-  const client = new Client({
-    apiUrl: process.env.REACT_APP_LANGGRAPH_API_URL,
-  });
+  const client = new Client();
   const indexID = process.env.REACT_APP_API_INDEX_ID
   // List available assistants
   const assistants = await client.assistants.search();

--- a/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
+++ b/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
@@ -1,55 +1,60 @@
-import React, { Dispatch, SetStateAction, Suspense } from 'react'
+import React, { Dispatch, SetStateAction, Suspense, useRef } from 'react'
 import FallBackVideoSingle from '../Fallback/FallBackVideoSingle';
 import VideoThumbnail from '../ChatMessagesList/VideoThumbnail';
 import StreamingTextEffect from '../StreamingText/StreamingTextEffect';
 import SeeMoreResultsButton from '../ChatMessagesList/SeeMoreResultsButton';
 import { Message } from '../ChatMessagesList/AIResponse';
+import ReactHlsPlayer from 'react-hls-player';
+import helpersFunctions from '../../helpers/helpers';
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 interface AIResponseVideoSearch {
     message: Message
-    showAllVideos: boolean;
-    setShowAllVideos: Dispatch<SetStateAction<boolean>>
-    videosLengthMoreThan3: boolean | undefined
-    formattedDurations: string[],
     handleVideoClick: (index: number | undefined) => void
 }
 
-export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message, showAllVideos, setShowAllVideos, videosLengthMoreThan3, formattedDurations, handleVideoClick }) => {
+const getFirstParagraph = (text: string): string => {
+  if (!text) return '';
+  const paragraphs = text.split('\n\n');
+  return paragraphs[0];
+};
+
+export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message, handleVideoClick }) => {
+  const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
+  console.log(message.text)
     return (
-        <div className=''>
-        <ul className={'flex flex-wrap pb-3 gap-[12px]'}>
-        {message.toolsData && message.toolsData.slice(0, showAllVideos ? undefined : 3).map((video, index) => {
-          return (
-            <li key={index} className=" ">
-              <div className="flex flex-row justify-between items-start gap-[12px]">
-                { video  ?  
-                <Suspense fallback={<FallBackVideoSingle oneThumbnail={message?.toolsData && message.toolsData.length <= 1} index={index} duration={formattedDurations[index]}/>}>
-                  <VideoThumbnail
-                    thumbnailUrl={video.thumbnail_url}
-                    index={index}
-                    onClick={() => handleVideoClick(index)}
-                    duration={formattedDurations[index]}
-                    oneThumbnail={message?.toolsData && message.toolsData.length <= 1}
-                  />  
-                </Suspense>
-                : <FallBackVideoSingle oneThumbnail={message?.toolsData && message.toolsData.length <= 1} index={index} duration={formattedDurations[index]}/>}
-                <div className="flex-grow w-[400px]">
-                  {/* Apply the streaming effect to the text */}
-                  { video && <StreamingTextEffect text={video.video_title} />}
-                </div>
+      <div className="flex flex-col gap-[12px]">
+      {message?.text && urlsFromMessageText.length > 0 && (
+        <p className="text-[#333431] font-aeonik text-base">
+          {<StreamingTextEffect text={getFirstParagraph(message.text)} />}
+        </p>
+      )}
+      <div className="flex flex-row justify-between items-start gap-[12px]">
+        { message  ?  
+        // <Suspense fallback={<FallBackVideoSingle oneThumbnail={message?.toolsData && message.toolsData.length <= 1} index={index} duration={formattedDurations[index]}/>}>
+        <Suspense>
+            {message?.text && (
+              <div className="video-urls-container flex flex-col gap-4">
+                {urlsFromMessageText.map((video, index) => (
+                  <ReactHlsPlayer
+                    key={index}
+                    src={video.url}
+                    width={'854px'}
+                    controls={true}
+                    height="520px"
+                    playerRef={useRef(null)}
+                    className={'rounded'}
+                  />
+                ))}
               </div>
-            </li>
-          );
-        })}
-      </ul>
-    {videosLengthMoreThan3 && (
-      <SeeMoreResultsButton
-        showAllVideos={showAllVideos}
-        setShowAllVideos={setShowAllVideos}
-        message={message}
-      />
-    )}
-  </div>
+            )}
+        </Suspense> : ''}
+        {/* // : <FallBackVideoSingle oneThumbnail={message?.toolsData && message.toolsData.length <= 1} index={index} />} */}
+        <div className="flex-grow w-[400px]">
+          {/* Apply the streaming effect to the text */}
+          {/* { message.text && <StreamingTextEffect text={message.text} />} */}
+        </div>
+      </div>
+      </div>
     )
 }
 

--- a/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
+++ b/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
@@ -12,20 +12,16 @@ interface AIResponseVideoSearch {
     handleVideoClick: (index: number | undefined) => void
 }
 
-const getFirstParagraph = (text: string): string => {
-  if (!text) return '';
-  const paragraphs = text.split('\n\n');
-  return paragraphs[0];
-};
-
 export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message, handleVideoClick }) => {
   const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
+  const firstParagraphFromMessageText = helpersFunctions.getFirstParagraph(message.text as string)
+  // TODO: let's use it as a hotfix for now, but for the future it's better to handle a general json instead
   console.log(message.text)
     return (
       <div className="flex flex-col gap-[12px]">
       {message?.text && urlsFromMessageText.length > 0 && (
         <p className="text-[#333431] font-aeonik text-base">
-          {<StreamingTextEffect text={getFirstParagraph(message.text)} />}
+          {<StreamingTextEffect text={firstParagraphFromMessageText} />}
         </p>
       )}
       <div className="flex flex-row justify-between items-start gap-[12px]">

--- a/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
+++ b/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
@@ -6,26 +6,26 @@ import SeeMoreResultsButton from '../ChatMessagesList/SeeMoreResultsButton';
 import { Message } from '../ChatMessagesList/AIResponse';
 import ReactHlsPlayer from 'react-hls-player';
 import helpersFunctions from '../../helpers/helpers';
+import { VideoInfo } from '../../types/messageTypes';
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 interface AIResponseVideoSearch {
+    urlsFromMessageText: VideoInfo[]
+    showAllVideos: boolean;
+    setShowAllVideos: Dispatch<SetStateAction<boolean>>
+    videosLengthMoreThan3: boolean | undefined
     message: Message
     handleVideoClick: (index: number | undefined) => void
 }
 
-export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message, handleVideoClick }) => {
-  const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
+export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({urlsFromMessageText, showAllVideos, setShowAllVideos,  message, handleVideoClick, videosLengthMoreThan3 }) => {
   const firstParagraphFromMessageText = helpersFunctions.getFirstParagraph(message.text as string)
-
-  if (urlsFromMessageText.length === 0) {
-    return null
-  }
-  // TODO: let's use it as a hotfix for now, but for the future it's better to handle a general json instead
+  const playerRefs = urlsFromMessageText.map(() => useRef(null))
   console.log(message.text)
     return (
       <div className="flex flex-col gap-[12px]">
       {message?.text && urlsFromMessageText.length > 0 && (
         <p className="text-[#333431] font-aeonik text-base">
-          {<StreamingTextEffect text={firstParagraphFromMessageText} />}
+          { <StreamingTextEffect text={firstParagraphFromMessageText} />}
         </p>
       )}
       <div className="flex flex-row justify-between items-start gap-[12px]">
@@ -34,14 +34,14 @@ export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message
         <Suspense>
             {message?.text && (
               <div className="video-urls-container flex flex-col gap-4">
-                {urlsFromMessageText.map((video, index) => (
+                {urlsFromMessageText.slice(0, showAllVideos ? undefined : 3).map((video, index) => (
                   <ReactHlsPlayer
                     key={index}
                     src={video.url}
                     width={'854px'}
                     controls={true}
                     height="520px"
-                    playerRef={useRef(null)}
+                    playerRef={playerRefs[index]}
                     className={'rounded'}
                   />
                 ))}
@@ -54,6 +54,14 @@ export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message
           {/* { message.text && <StreamingTextEffect text={message.text} />} */}
         </div>
       </div>
+      {videosLengthMoreThan3 && (
+        <SeeMoreResultsButton
+          showAllVideos={showAllVideos}
+          setShowAllVideos={setShowAllVideos}
+          message={message}
+          videosUrls={urlsFromMessageText}
+        />
+      )}
       </div>
     )
 }

--- a/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
+++ b/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
@@ -15,6 +15,10 @@ interface AIResponseVideoSearch {
 export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({ message, handleVideoClick }) => {
   const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
   const firstParagraphFromMessageText = helpersFunctions.getFirstParagraph(message.text as string)
+
+  if (urlsFromMessageText.length === 0) {
+    return null
+  }
   // TODO: let's use it as a hotfix for now, but for the future it's better to handle a general json instead
   console.log(message.text)
     return (

--- a/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
+++ b/frontend/src/components/AIResponse/AIResponseVideoSearch.tsx
@@ -19,6 +19,9 @@ interface AIResponseVideoSearch {
 
 export const AIResponseVideoSearch: React.FC<AIResponseVideoSearch> = ({urlsFromMessageText, showAllVideos, setShowAllVideos,  message, handleVideoClick, videosLengthMoreThan3 }) => {
   const firstParagraphFromMessageText = helpersFunctions.getFirstParagraph(message.text as string)
+  if (urlsFromMessageText.length === 0) {
+    return null
+  }
   const playerRefs = urlsFromMessageText.map(() => useRef(null))
   console.log(message.text)
     return (

--- a/frontend/src/components/ChatMessagesList/AIResponse.tsx
+++ b/frontend/src/components/ChatMessagesList/AIResponse.tsx
@@ -48,12 +48,12 @@ const AIResponse: React.FC<AIResponseProps> = ({ message, handleShow }) => {
     handleShow(index, indexOfMessage )
   };
 
-  const formattedDurations =
-    message?.toolsData?.map((video) =>
-      formatTime(Math.round(video.start), Math.round(video.end))
-    ) || [];
+  // const formattedDurations =
+  //   message?.toolsData?.map((video) =>
+  //     formatTime(Math.round(video.start), Math.round(video.end))
+  //   ) || [];
   
-  const videosLengthMoreThan3 = message?.toolsData && message.toolsData.length > 3
+  // const videosLengthMoreThan3 = message?.toolsData && message.toolsData.length > 3
 
   return (
     <>
@@ -63,21 +63,23 @@ const AIResponse: React.FC<AIResponseProps> = ({ message, handleShow }) => {
           }
           <div className={'aiBubble ml-[40px]  whitespace-pre-line gap-4'}>
               <div>
-                {message?.toolsData ? (
+                {message ? (
                       <AIResponseVideoSearch 
-                        videosLengthMoreThan3={videosLengthMoreThan3}
+                        // videosLengthMoreThan3={videosLengthMoreThan3}
                         message={message}
-                        formattedDurations={formattedDurations}
+                        // formattedDurations={formattedDurations}
                         handleVideoClick={handleVideoClick}
-                        showAllVideos={showAllVideos}
-                        setShowAllVideos={setShowAllVideos}
+                        // showAllVideos={showAllVideos}
+                        // setShowAllVideos={setShowAllVideos}
                         />
                   // ) : <SkeletonChatVideoCard/>}
                   ) : ''}
               </div>
+              <div className="mt-[12px]">
               { hasValidMessage ? (
                 <ExtendMessage agent={message.linkText} message={message.text}/>
             ) : <ExtendMessage agent='error' message={message.text}/>}
+            </div>
           </div>
         </div>
       

--- a/frontend/src/components/ChatMessagesList/AIResponse.tsx
+++ b/frontend/src/components/ChatMessagesList/AIResponse.tsx
@@ -47,10 +47,9 @@ const AIResponse: React.FC<AIResponseProps> = ({ message, handleShow }) => {
     handleShow(index, indexOfMessage )
   };
 
-  const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
-  if (urlsFromMessageText.length === 0) {
-    return null
-  }
+  const urlsFromMessageText = message.linkText === 'REFLECT' ? 
+    helpersFunctions.parseCloudFrontUrls(message.text as string) : 
+    [];
   const videosLengthMoreThan3 = urlsFromMessageText.length !== 0 && urlsFromMessageText.length > 3 
   // TODO: let's use it as a hotfix for now, but for the future it's better to handle a general json instead
   return (

--- a/frontend/src/components/ChatMessagesList/AIResponse.tsx
+++ b/frontend/src/components/ChatMessagesList/AIResponse.tsx
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import { ReactComponent as AIIcon } from '../../icons/ai.svg';
-import { formatTime } from './formatTime';
 import { ModalType } from '../../types/messageTypes';
 import { ActionType, useChat } from '../../widgets/VideoAssistant/hooks/useChat';
 import { AIResponseVideoSearch } from '../AIResponse/AIResponseVideoSearch';
 import AIResponseHeader from '../AIResponse/AIResponseHeader';
 import SkeletonChatVideoCard from '../../skeletons/SkeletonChatVideoCard';
 import ExtendMessage from './helpers/ExtendMessage';
+import helpersFunctions from '../../helpers/helpers';
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 
 export interface Message {
@@ -48,13 +47,12 @@ const AIResponse: React.FC<AIResponseProps> = ({ message, handleShow }) => {
     handleShow(index, indexOfMessage )
   };
 
-  // const formattedDurations =
-  //   message?.toolsData?.map((video) =>
-  //     formatTime(Math.round(video.start), Math.round(video.end))
-  //   ) || [];
-  
-  // const videosLengthMoreThan3 = message?.toolsData && message.toolsData.length > 3
-
+  const urlsFromMessageText = helpersFunctions.parseCloudFrontUrls(message.text as string)
+  if (urlsFromMessageText.length === 0) {
+    return null
+  }
+  const videosLengthMoreThan3 = urlsFromMessageText.length !== 0 && urlsFromMessageText.length > 3 
+  // TODO: let's use it as a hotfix for now, but for the future it's better to handle a general json instead
   return (
     <>
         <div className={'relative w-[680px]'}>
@@ -65,15 +63,14 @@ const AIResponse: React.FC<AIResponseProps> = ({ message, handleShow }) => {
               <div>
                 {message ? (
                       <AIResponseVideoSearch 
-                        // videosLengthMoreThan3={videosLengthMoreThan3}
+                        urlsFromMessageText={urlsFromMessageText}
+                        videosLengthMoreThan3={videosLengthMoreThan3}
                         message={message}
-                        // formattedDurations={formattedDurations}
                         handleVideoClick={handleVideoClick}
-                        // showAllVideos={showAllVideos}
-                        // setShowAllVideos={setShowAllVideos}
+                        showAllVideos={showAllVideos}
+                        setShowAllVideos={setShowAllVideos}
                         />
-                  // ) : <SkeletonChatVideoCard/>}
-                  ) : ''}
+                  ) : <SkeletonChatVideoCard/>}
               </div>
               <div className="mt-[12px]">
               { hasValidMessage ? (

--- a/frontend/src/components/ChatMessagesList/SeeMoreResultsButton.tsx
+++ b/frontend/src/components/ChatMessagesList/SeeMoreResultsButton.tsx
@@ -1,19 +1,21 @@
 import React from "react"
 import ArrowIcon from "../../icons/ArrowIcon"
 import { Message } from "./AIResponse"
+import { VideoInfo } from "../../types/messageTypes";
 
 interface SeeMoreResultsButtonProps {
     showAllVideos: boolean,
     message: Message,
     setShowAllVideos: React.Dispatch<React.SetStateAction<boolean>>;
+    videosUrls: VideoInfo[]
 }
 
-export const SeeMoreResultsButton: React.FC<SeeMoreResultsButtonProps> = ({ showAllVideos, setShowAllVideos, message }) => {
-    const videosAmountLeft = message?.toolsData && message.toolsData.length - 3
+export const SeeMoreResultsButton: React.FC<SeeMoreResultsButtonProps> = ({ showAllVideos, setShowAllVideos, message, videosUrls }) => {
+    const videosAmountLeft = videosUrls.length - 3
     return (
         <button 
             onClick={() => setShowAllVideos(!showAllVideos)} 
-            className={'text-[#006F33] flex flex-row gap-1 justify-center items-center font-aeonik'}
+            className={'text-[#006F33] flex flex-row gap-1 justify-start items-center font-aeonik'}
         >
             {showAllVideos ? 'Show Less' : `See ${videosAmountLeft} more results`}
             <ArrowIcon direction={showAllVideos}/>

--- a/frontend/src/helpers/helpers.tsx
+++ b/frontend/src/helpers/helpers.tsx
@@ -25,6 +25,12 @@ const helpersFunctions = {
       });
     },
 
+    getFirstParagraph : (text: string): string => {
+      if (!text) return '';
+      const paragraphs = text.split('\n\n');
+      return paragraphs[0];
+    },
+
     parseCloudFrontUrls : (text: string): VideoInfo[] => {
       const urls: VideoInfo[] = [];
       const urlRegex = /https:\/\/[^\s)]+(?:cloudfront|ngrok)[^\s)]+/g;

--- a/frontend/src/helpers/helpers.tsx
+++ b/frontend/src/helpers/helpers.tsx
@@ -1,6 +1,6 @@
 import { Dispatch } from 'react';
 import { ActionType } from '../widgets/VideoAssistant/hooks/useChatTypes';
-import { ModalType } from '../types/messageTypes';
+import { ModalType, VideoInfo } from '../types/messageTypes';
 
 const helpersFunctions = {
     updateChatPanelMessages: (
@@ -23,6 +23,18 @@ const helpersFunctions = {
           },
         ],
       });
+    },
+
+    parseCloudFrontUrls : (text: string): VideoInfo[] => {
+      const urls: VideoInfo[] = [];
+      const urlRegex = /https:\/\/[^\s)]+(?:cloudfront|ngrok)[^\s)]+/g;
+      
+      let match;
+      while ((match = urlRegex.exec(text)) !== null) {
+        urls.push({ url: match[0] });
+      }
+      console.log('Found cloudfront/Ngrok server urls:', urls);
+      return urls;
     },
   
     openPanelModal: (

--- a/frontend/src/types/messageTypes.ts
+++ b/frontend/src/types/messageTypes.ts
@@ -4,6 +4,10 @@ export interface Message {
     link?: string;
     linkText?: string;
   }
+
+export interface VideoInfo {
+    url: string;
+  }
   
 export interface QuestionMessage extends Message {
     twelveText?: string;


### PR DESCRIPTION
- [x]  frontend hotfix  (without ready to go JSON from backend) 
- [ ]  backend JSON short summary for each worker response 
- [ ]  backend JSON for each video => thumbnail url, videoURL, start + end, confidence rate, tittle for each video 
- [ ] backend => hide all irrelevant information from the user, such as index IDs, etc 
- [ ] frontend => update the frontend to handle all changes with JSON

When the URL of the clip arrives, we need to display it gracefully using a video player or players, so that the user can launch, play, and interact with the video on the frontend


![image](https://github.com/user-attachments/assets/db600a75-46e5-45e7-bfcc-a064b1c81e4f)

