### PR TITLE
Add internal network and container healthchecks

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,44 @@
 services:
   langgraph-api:
+    depends_on:
+      langgraph-postgres:
+        condition: service_healthy
+      langgraph-redis:
+        condition: service_healthy
+    networks:
+      - jockey_internal  
+      - default         
+    ports:
+      - "8123:8000"
     volumes:
-      - ${HOST_PUBLIC_DIR}:/var/www/jockey/public
-      - ${HOST_VECTOR_DB_DIR}:/var/lib/jockey/vector_db
+      - ${HOST_PUBLIC_DIR}:/app/public
+      - ${HOST_VECTOR_DB_DIR}:/app/vector_db
+
+  langgraph-postgres:
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - jockey_internal
+    expose:
+      - "5432"  
+
+  langgraph-redis:
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - jockey_internal
+    expose:
+      - "6379" 
+      
+networks:
+  jockey_internal:
+    driver: bridge
+    internal: true  
+  default:             
+    driver: bridge 

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,8 +11,8 @@ services:
     ports:
       - "8123:8000"
     volumes:
-      - ${HOST_PUBLIC_DIR}:/app/public
-      - ${HOST_VECTOR_DB_DIR}:/app/vector_db
+      - ${HOST_PUBLIC_DIR}:/var/www/jockey/public
+      - ${HOST_VECTOR_DB_DIR}:/var/lib/jockey/vector_db
 
   langgraph-postgres:
     healthcheck:


### PR DESCRIPTION
This is expected to be a transparent change that won't change the workflows or functionality for users. It expands on the services already defined by langgraph.

**This PR does two things:** 
1. Adds a new "jockey-internal" network for the existing server/postgres/redis containers, while also allowing the jockey-server to continue being available on the default network. This makes sense because only the langgraph-api container needs access to those other containers
2. Adds some basic healthchecks for the redis/postgres contianers to ensure they are in good shape before bringing up the langgraph api container